### PR TITLE
Fix gulp.task bug

### DIFF
--- a/Front End Tools/Gulp/README.md
+++ b/Front End Tools/Gulp/README.md
@@ -309,7 +309,7 @@ gulp.task('webserver', function() {
 		}));
 });
 
-gulp.task('default', ['watch', 'webserver']);
+gulp.task('default', ['styles', 'scripts', 'content', 'images', 'watch', 'webserver']);
 ```
 
   [1]: https://github.com/JohnUdacity/gulp-start


### PR DESCRIPTION
Added tasks to gulp.task; otherwise, gulp didn't work properly, i.e. it ignores other tasks and generate empty `build/` folder.